### PR TITLE
Remove debug helpers from app

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@ from flask import Flask, jsonify, Response
 from config import Config
 from utils.errors import register_error_handlers
 from auth import require_api_key
-print("LOADING APP.PY")
 # Insert the parent directory (project root) into sys.path so that "src/" becomes visible.
 def create_app():
     app = Flask(__name__)
@@ -32,16 +31,6 @@ def create_app():
     def protected():
         return {"status": "success"}, 200
     
-    def test_with_empty_api_key_header(client):
-        response = client.get('/protected', headers={"X-API-Key": ""})
-        assert response.status_code == 401
-        assert response.json["status"] == "error"
-    # (or however your error payload is shaped)
-
-    def test_with_lowercase_header_name(client):
-        response = client.get('/protected', headers={"x-api-key": "test-key"})
-        assert response.status_code == 200
-
     return app
 
 if __name__ == "__main__":

--- a/auth.py
+++ b/auth.py
@@ -1,6 +1,4 @@
 from flask import request, jsonify, current_app
-
-print("LOADING APP.PY")
 def require_api_key(view_func):
     def wrapper(*args, **kwargs):
         api_key = request.headers.get("X-API-Key")

--- a/firestore_client.py
+++ b/firestore_client.py
@@ -27,8 +27,7 @@ class FirestoreClient:
             doc_ref.update(data)
             updated_doc = doc_ref.get()
             return {"id": doc_id, **updated_doc.to_dict()}
-        except Exception as e:
-            print(f"Error updating document: {e}")
+        except Exception:
             return None
 
     def delete_document(self, collection, doc_id):

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -7,10 +7,6 @@ import pytest
 import sys
 import os
 
-print("\n=== PYTHON sys.path BEGIN ===")
-for idx, p in enumerate(sys.path):
-    print(f"{idx:2d}: {p!r}")
-print("=== PYTHON sys.path END ===\n")
 
 from app import create_app   # ← This is where pytest was failing
 


### PR DESCRIPTION
## Summary
- clean up app factory
- drop leftover print statements
- delete helper functions used for testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6845e0489c948333b990d0d4143bdabe