### PR TITLE
Add explicit document-id create route

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,8 @@
 from flask import Flask, jsonify, Response
+# Application factory for the Firestore adapter service
 from config import Config
 from utils.errors import register_error_handlers
 from auth import require_api_key
-print("LOADING APP.PY")
 # Insert the parent directory (project root) into sys.path so that "src/" becomes visible.
 def create_app():
     app = Flask(__name__)
@@ -31,16 +31,6 @@ def create_app():
     @require_api_key
     def protected():
         return {"status": "success"}, 200
-    
-    def test_with_empty_api_key_header(client):
-        response = client.get('/protected', headers={"X-API-Key": ""})
-        assert response.status_code == 401
-        assert response.json["status"] == "error"
-    # (or however your error payload is shaped)
-
-    def test_with_lowercase_header_name(client):
-        response = client.get('/protected', headers={"x-api-key": "test-key"})
-        assert response.status_code == 200
 
     return app
 

--- a/auth.py
+++ b/auth.py
@@ -1,6 +1,4 @@
 from flask import request, jsonify, current_app
-
-print("LOADING APP.PY")
 def require_api_key(view_func):
     def wrapper(*args, **kwargs):
         api_key = request.headers.get("X-API-Key")

--- a/firestore_client.py
+++ b/firestore_client.py
@@ -14,6 +14,12 @@ class FirestoreClient:
         doc_ref.set(data)
         return {"id": doc_ref.id, **data}
 
+    def create_document_with_id(self, collection, doc_id, data):
+        """Create a document using a caller-provided ID."""
+        doc_ref = self.db.collection(collection).document(doc_id)
+        doc_ref.set(data)
+        return {"id": doc_id, **data}
+
     def read_document(self, collection, doc_id):
         doc = self.db.collection(collection).document(doc_id).get()
         if doc.exists:

--- a/routes/documents.py
+++ b/routes/documents.py
@@ -113,6 +113,14 @@ def read_document(collection, doc_id):
     else:
         return jsonify({"status": "error", "message": "Not found"}), 404
 
+@bp.route("/documents/<collection>/<doc_id>", methods=["POST"])
+@require_api_key
+def create_document_with_id(collection, doc_id):
+    data = request.json
+    client = get_client()
+    result = client.create_document_with_id(collection, doc_id, data)
+    return jsonify({"status": "success", "data": result}), 201
+
 @bp.route("/documents/<collection>/<doc_id>", methods=["PUT"])
 @require_api_key
 def update_document(collection, doc_id):


### PR DESCRIPTION
## Summary
- add `create_document_with_id` to the Firestore client
- expose POST `/documents/<collection>/<doc_id>` endpoint
- clean up debug prints and stray test code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847e381e49c83338a5ef0f6a629b994