### PR TITLE
Improve logging and error handling

### DIFF
--- a/firestore_client.py
+++ b/firestore_client.py
@@ -1,6 +1,10 @@
 from google.cloud import firestore
+from google.api_core.exceptions import NotFound
 import os
 import logging
+
+
+logger = logging.getLogger(__name__)
 
 class FirestoreClient:
     def __init__(self, credentials_path=None):
@@ -10,34 +14,60 @@ class FirestoreClient:
         self.db = firestore.Client()
 
     def create_document(self, collection, data):
-        doc_ref = self.db.collection(collection).document()
-        doc_ref.set(data)
-        return {"id": doc_ref.id, **data}
+        """Create a new document and return its contents."""
+        try:
+            doc_ref = self.db.collection(collection).document()
+            doc_ref.set(data)
+            logger.info("Created document %s in %s", doc_ref.id, collection)
+            return {"id": doc_ref.id, **data}
+        except Exception:
+            logger.exception("Failed to create document in %s", collection)
+            raise
 
     def create_document_with_id(self, collection, doc_id, data):
         """Create a document using a caller-provided ID."""
-        doc_ref = self.db.collection(collection).document(doc_id)
-        doc_ref.set(data)
-        return {"id": doc_id, **data}
+        try:
+            doc_ref = self.db.collection(collection).document(doc_id)
+            doc_ref.set(data)
+            logger.info("Created document %s/%s", collection, doc_id)
+            return {"id": doc_id, **data}
+        except Exception:
+            logger.exception("Failed to create document %s/%s", collection, doc_id)
+            raise
 
     def read_document(self, collection, doc_id):
-        doc = self.db.collection(collection).document(doc_id).get()
-        if doc.exists:
-            return {"id": doc.id, **doc.to_dict()}
-        else:
+        """Return a document or None if it does not exist."""
+        try:
+            doc = self.db.collection(collection).document(doc_id).get()
+            if doc.exists:
+                logger.info("Read document %s/%s", collection, doc_id)
+                return {"id": doc.id, **doc.to_dict()}
             return None
+        except Exception:
+            logger.exception("Failed to read document %s/%s", collection, doc_id)
+            raise
 
     def update_document(self, collection, doc_id, data):
+        """Update an existing document."""
         doc_ref = self.db.collection(collection).document(doc_id)
         try:
             doc_ref.update(data)
             updated_doc = doc_ref.get()
+            logger.info("Updated document %s/%s", collection, doc_id)
             return {"id": doc_id, **updated_doc.to_dict()}
-        except Exception as e:
-            logging.error("Error updating document", exc_info=e)
-            return None
+        except Exception:
+            logger.exception("Failed to update document %s/%s", collection, doc_id)
+            raise
 
     def delete_document(self, collection, doc_id):
-        doc_ref = self.db.collection(collection).document(doc_id)
-        doc_ref.delete()
-        return {"id": doc_id}
+        """Delete a document by ID."""
+        try:
+            doc_ref = self.db.collection(collection).document(doc_id)
+            if not doc_ref.get().exists:
+                raise NotFound("Document not found")
+            doc_ref.delete()
+            logger.info("Deleted document %s/%s", collection, doc_id)
+            return {"id": doc_id}
+        except Exception:
+            logger.exception("Failed to delete document %s/%s", collection, doc_id)
+            raise

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -3,30 +3,44 @@ import uuid
 import logging
 from google.api_core.exceptions import NotFound
 
+logger = logging.getLogger(__name__)
+
 def register_error_handlers(app):
     @app.errorhandler(404)
     def not_found_error(e):
-        return jsonify({"status": "error", "message": "Resource not found"}), 404
+        correlation_id = uuid.uuid4().hex
+        logger.warning("Not found [%s]", correlation_id)
+        return jsonify({"status": "error", "message": "Resource not found", "correlation_id": correlation_id}), 404
 
     @app.errorhandler(400)
     def bad_request_error(e):
-        return jsonify({"status": "error", "message": "Bad request"}), 400
+        correlation_id = uuid.uuid4().hex
+        logger.warning("Bad request [%s]", correlation_id)
+        return jsonify({"status": "error", "message": "Bad request", "correlation_id": correlation_id}), 400
+
+    @app.errorhandler(405)
+    def method_not_allowed_error(e):
+        correlation_id = uuid.uuid4().hex
+        logger.warning("Method not allowed [%s]", correlation_id)
+        return jsonify({"status": "error", "message": "Method not allowed", "correlation_id": correlation_id}), 405
 
     @app.errorhandler(500)
     def internal_server_error(e):
         correlation_id = uuid.uuid4().hex
-        logging.exception("Unhandled server error [%s]", correlation_id, exc_info=e)
+        logger.exception("Unhandled server error [%s]", correlation_id, exc_info=e)
         return jsonify({"status": "error", "message": "Internal server error", "correlation_id": correlation_id}), 500
 
     # Optionally, handle Firestore NotFound for any endpoint
     @app.errorhandler(NotFound)
     def firestore_not_found(e):
-        return jsonify({"status": "error", "message": "Document not found"}), 404
+        correlation_id = uuid.uuid4().hex
+        logger.warning("Document not found [%s]", correlation_id)
+        return jsonify({"status": "error", "message": "Document not found", "correlation_id": correlation_id}), 404
 
     @app.errorhandler(Exception)
     def unhandled_exception(e):
         correlation_id = uuid.uuid4().hex
-        logging.exception("Unhandled exception [%s]", correlation_id, exc_info=e)
+        logger.exception("Unhandled exception [%s]", correlation_id, exc_info=e)
         return jsonify({"status": "error", "message": "Internal server error", "correlation_id": correlation_id}), 500
 
     # You can add more handlers as needed (e.g., for custom exceptions)


### PR DESCRIPTION
## Summary
- log Firestore operations and raise on error
- surface `NotFound` errors in routes
- add correlation IDs and a 405 handler in the error helpers

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_b_6847ea407ca88333b97382b2ef712473