### PR TITLE
Use Secret Manager for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This service exposes a minimal REST API for interacting with Google Firestore. I
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and fill in the required values.
+1. Copy `.env.example` to `.env` and fill in the required values. If you deploy
+   without an `.env` file, set `API_KEYS_SECRET_NAME` to a Secret Manager secret
+   containing your comma-separated API keys.
 2. Install dependencies:
    ```bash
    pip install -r requirements.txt
@@ -22,6 +24,6 @@ pytest -q
 
 ## Deployment
 
-The GitHub workflow builds a Docker image and deploys to Cloud Run. The service expects authenticated access via API keys. Update `API_KEYS` in your environment configuration and ensure Cloud Run authentication matches your needs.
+The GitHub workflow builds a Docker image and deploys to Cloud Run. The service expects authenticated access via API keys. You can provide the keys directly using the `API_KEYS` environment variable or set `API_KEYS_SECRET_NAME` so the service loads them from Secret Manager. Ensure Cloud Run authentication matches your needs.
 
 

--- a/config.py
+++ b/config.py
@@ -3,9 +3,42 @@ import sys
 import json
 import logging
 from dotenv import load_dotenv
+from google.cloud import secretmanager
 
 # Load .env file if present (only affects local dev, safe to call always)
 load_dotenv()
+
+
+def load_api_keys_from_secret_manager():
+    """Populate API_KEYS from Secret Manager if not set."""
+    if os.getenv("API_KEYS"):
+        return
+
+    secret_name = os.getenv("API_KEYS_SECRET_NAME")
+    if not secret_name:
+        # Nothing to load
+        return
+
+    project_id = os.getenv("GCP_PROJECT") or os.getenv("PROJECT_ID")
+    if secret_name.startswith("projects/"):
+        secret_path = f"{secret_name}/versions/latest"
+    elif project_id:
+        secret_path = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
+    else:
+        logging.error("API_KEYS_SECRET_NAME set but project ID missing")
+        return
+
+    try:
+        client = secretmanager.SecretManagerServiceClient()
+        response = client.access_secret_version(name=secret_path)
+        secret_value = response.payload.data.decode("utf-8")
+        os.environ["API_KEYS"] = secret_value
+        logging.info("Loaded API keys from Secret Manager")
+    except Exception:
+        logging.exception("Failed to load API keys from Secret Manager")
+
+
+load_api_keys_from_secret_manager()
 
 class Config:
     # Comma-separated API keys (string → list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 google-cloud-firestore
 gunicorn
 python-dotenv
+google-cloud-secret-manager


### PR DESCRIPTION
## Summary
- load API keys from Secret Manager when not provided via env vars
- document Secret Manager usage in the README
- include `google-cloud-secret-manager` as a dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d53bf2ff88333921006095d44add4